### PR TITLE
Compatibility-Tag removed

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -24,10 +24,6 @@
 		<excludedpackage version="6.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
 	</excludedpackages>
 
-	<compatibility>
-		<api version="2018"/>
-	</compatibility>
-
 	<instructions type="install">
 		<instruction type="file"/>
 		<instruction type="userOption"/>


### PR DESCRIPTION
The compatibility tag regarding API versions is obsolete. 
The API-Versions were abolished with the release of WSC 5.2. 

See also: https://docs.woltlab.com/5.5/package/package-xml/#compatibility